### PR TITLE
Fix for cached component not rendered

### DIFF
--- a/componentrenderer/src/main/java/de/datenhahn/vaadin/componentrenderer/ComponentRenderer.java
+++ b/componentrenderer/src/main/java/de/datenhahn/vaadin/componentrenderer/ComponentRenderer.java
@@ -129,22 +129,21 @@ public class ComponentRenderer extends Grid.AbstractRenderer<Component> implemen
                     putComponent(itemId, current);
                     componentsInUse.add(current);
                 }
-            }
 
+                // find all components, which are no longer in use for this item id
+                Set<Component> itemIdComponents = components.get(itemId);
 
-            // find all components, which are no longer in use for this item id
-            Set<Component> itemIdComponents = components.get(itemId);
+                if (itemIdComponents != null) {
 
-            if (itemIdComponents != null) {
+                    Set<Component> unusedComponents = new HashSet<>(itemIdComponents);
+                    unusedComponents.removeAll(componentsInUse);
 
-                Set<Component> unusedComponents = new HashSet<>(itemIdComponents);
-                unusedComponents.removeAll(componentsInUse);
+                    // remove unused components from current tracking
+                    components.get(itemId).removeAll(unusedComponents);
 
-                // remove unused components from current tracking
-                components.get(itemId).removeAll(unusedComponents);
-
-                // destroy unused components
-                destroyComponents(unusedComponents);
+                    // destroy unused components
+                    destroyComponents(unusedComponents);
+                }
             }
         }
 


### PR DESCRIPTION
This is to fix the case where for example : you have two tab sheets, with ComponentGrid that has two columns at least and you have the Component getComponent(T bean); method implementation to returned a cached component instead of a new component always. 

When you switch the tab sheets, the cached component will be removed as unused component prematurely by another column that is not part of the same renderer
